### PR TITLE
Make Battery voltage and capacity in SIM configurable

### DIFF
--- a/config/gz_ros_bridge.yaml
+++ b/config/gz_ros_bridge.yaml
@@ -9,6 +9,9 @@
   direction: GZ_TO_ROS  # can be BIDIRECTIONAL or ROS_TO_GZ
 
 - ros_topic_name: "battery/battery_state"
+  # gz topic --echo --topic /model/plucky/battery/lithium_battery/state
+  # Note: make sure percentage is reported by GZ in 0..1 range, as ROS2 message requires that.
+  #       see <fix_issue_225>false</fix_issue_225> in battery.xacro
   # <model_name> and <namespace> must be replaced by launch file:
   gz_topic_name: /model/<model_name>/battery/<namespace>/lithium_battery/state
   ros_type_name: "sensor_msgs/msg/BatteryState"

--- a/description/battery.xacro
+++ b/description/battery.xacro
@@ -22,22 +22,29 @@
         <state_interface name="charge"/>
         <state_interface name="capacity"/>
         <state_interface name="percentage"/>
-    </sensor>
+        <state_interface name="power_supply_status"/>
+        <state_interface name="power_supply_health"/>
+        <state_interface name="present"/>
+   </sensor>
   </ros2_control>
 
   <gazebo>
     <plugin name="gz::sim::systems::LinearBatteryPlugin" filename="gz-sim-linearbatteryplugin-system">
       <!--Li-ion battery spec from LIR18650 datasheet-->
       <battery_name>lithium_battery</battery_name>
-      <voltage>12.592</voltage>
-      <open_circuit_voltage_constant_coef>12.592</open_circuit_voltage_constant_coef>
+      <voltage>${open_circuit_voltage}</voltage>
+      <open_circuit_voltage_constant_coef>${open_circuit_voltage}</open_circuit_voltage_constant_coef>
       <open_circuit_voltage_linear_coef>-2.0</open_circuit_voltage_linear_coef>
-      <initial_charge>2.4</initial_charge>
-      <capacity>2.5 </capacity>
+      <initial_charge>${battery_capacity * 0.9}</initial_charge>
+      <capacity>${battery_capacity}</capacity>
       <resistance>0.07</resistance>
       <power_load>6.6</power_load>
       <smooth_current_tau>2.0</smooth_current_tau>
-      <fix_issue_225>true</fix_issue_225>
+      <!-- if "fix_issue_225" is true, percentage is reported in 1..100 range which is wrong.
+               see https://github.com/gazebosim/gz-sim/issues/225 -->
+      <fix_issue_225>false</fix_issue_225>
+      <!-- https://github.com/gazebosim/gz-sim/pull/2696 -->
+      <invert_current_sign>true</invert_current_sign>
       <enable_recharge>true</enable_recharge>
       <!-- charging I = c / t, discharging I = P / V,
         charging I should be > discharging I -->

--- a/launch/launch_rviz.launch.py
+++ b/launch/launch_rviz.launch.py
@@ -55,6 +55,16 @@ def generate_launch_description():
         remappings=[('battery_state','battery/battery_state')]
     )
 
+    battery_pie_chart_relay = Node(
+        package='topic_tools',
+        executable='relay_field',
+        name='battery_pie_chart_relay',
+        output='screen',
+        respawn=True,
+        respawn_delay=2.0,
+        arguments=['battery/battery_state', 'battery/percentage', 'std_msgs/Float32', '{ data: m.percentage }', '--qos-reliability', 'reliable' ]
+    )
+
     joystick = IncludeLaunchDescription(
                 PythonLaunchDescriptionSource([os.path.join(package_path,'launch','joystick.launch.py')]
                 ), launch_arguments={'use_sim_time': use_sim_time}.items()
@@ -68,6 +78,7 @@ def generate_launch_description():
             description='Use simulation (Gazebo) clock if true'),
 
         joystick,
+        battery_pie_chart_relay,
         rviz,
         rviz_overlay
     ])

--- a/robots/dragger/description/robot.urdf.xacro
+++ b/robots/dragger/description/robot.urdf.xacro
@@ -38,6 +38,8 @@
     <xacro:property name="camera_offset_z" value="0.55"/>
     <xacro:include filename="../../../description/camera.xacro" />
 
+    <xacro:property name="open_circuit_voltage" value="12.592"/>
+    <xacro:property name="battery_capacity" value="50.0"/>
     <xacro:include filename="../../../description/battery.xacro" />
 
     <!-- xacro:include filename="../../../description/depth_camera.xacro" / -->

--- a/robots/plucky/description/robot.urdf.xacro
+++ b/robots/plucky/description/robot.urdf.xacro
@@ -38,6 +38,8 @@
     <xacro:property name="camera_offset_z" value="0.45"/>
     <xacro:include filename="../../../description/camera.xacro" />
 
+    <xacro:property name="open_circuit_voltage" value="12.592"/>
+    <xacro:property name="battery_capacity" value="20.0"/>
     <xacro:include filename="../../../description/battery.xacro" />
 
     <!-- xacro:include filename="../../../description/depth_camera.xacro" / -->

--- a/robots/turtle/description/robot.urdf.xacro
+++ b/robots/turtle/description/robot.urdf.xacro
@@ -23,6 +23,8 @@
 
     <xacro:include filename="ros2_control.xacro" />
 
+    <xacro:property name="open_circuit_voltage" value="14.0"/>
+    <xacro:property name="battery_capacity" value="2.5"/>
     <xacro:include filename="../../../description/battery.xacro" />
 
 </robot>


### PR DESCRIPTION
Make Battery voltage and capacity in SIM configurable:
```
    <xacro:property name="open_circuit_voltage" value="12.592"/>
    <xacro:property name="battery_capacity" value="50.0"/>
    <xacro:include filename="../../../description/battery.xacro" />
```